### PR TITLE
remove license boilerplate from NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,14 +1,2 @@
 liblithium
 Copyright 2021 Tesla, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.


### PR DESCRIPTION
this text is meant for inclusion in individual files, but we use SPDX instead