### PR TITLE
fix a warning in gimli.c when compiling on AVX512-capable processors

### DIFF
--- a/.github/workflows/scons-test.yml
+++ b/.github/workflows/scons-test.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - name: Show CPU information
+      run: |
+        lscpu
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/SConstruct
+++ b/SConstruct
@@ -192,3 +192,13 @@ portable_asr_env.Append(CPPDEFINES=["LITH_FORCE_PORTABLE_ASR"])
 build_with_env("dist/portable_asr", portable_asr_env)
 
 build_with_env("dist/arm", arm_env, test=False)
+
+# Build with AVX512VL explicitly enabled and disabled to cover both
+# cases regardless of whether the host supports it or not.
+avx512vl_env = host_env.Clone()
+avx512vl_env.Append(CCFLAGS="-mavx512vl")
+build_with_env("dist/avx512vl", avx512vl_env, test=False)
+
+no_avx512vl_env = host_env.Clone()
+no_avx512vl_env.Append(CCFLAGS="-mno-avx512vl")
+build_with_env("dist/no-avx512vl", no_avx512vl_env, test=False)

--- a/src/opt.h
+++ b/src/opt.h
@@ -47,4 +47,18 @@
 #define LITH_VECTORIZE 0
 #endif
 
+/*
+ * Rotate left by 24 bits can be achieved more efficiently with a byte shuffle,
+ * unless there is a vectorized rotate.
+ * vpshufb is part of SSSE3, and vprold is part of AVX512VL.
+ * Neon doesn't have a vector rotate, but does have shuffles.
+ */
+#if (defined(__SSSE3__) && !defined(__AVX512VL__)) || defined(__ARM_NEON)
+#define LITH_SHUFFLE_ROTATE 1
+#endif
+
+#ifndef LITH_SHUFFLE_ROTATE
+#define LITH_SHUFFLE_ROTATE 0
+#endif
+
 #endif /* LITHIUM_OPT_H */


### PR DESCRIPTION
print CPU info in the SCons workflow
