### PR TITLE
separate vectorized sponge operations to their own optimization flag

### DIFF
--- a/src/gimli_aead.c
+++ b/src/gimli_aead.c
@@ -54,7 +54,7 @@ static void encrypt_update(gimli_state *g, unsigned char *c,
 void gimli_aead_encrypt_update(gimli_state *g, unsigned char *c,
                                const unsigned char *m, size_t len)
 {
-#if (LITH_ABSORB_WORDS)
+#if (LITH_SPONGE_WORDS)
     const size_t first_block_len = (GIMLI_RATE - g->offset) % GIMLI_RATE;
     if (len >= GIMLI_RATE + first_block_len)
     {
@@ -64,7 +64,7 @@ void gimli_aead_encrypt_update(gimli_state *g, unsigned char *c,
         len -= first_block_len;
         do
         {
-#if (LITH_VECTORIZE)
+#if (LITH_SPONGE_VECTORS)
             typedef uint32_t block_t
                 __attribute__((vector_size(16), aligned(1)));
             *(block_t *)c = *(block_t *)g->state ^= *(const block_t *)m;
@@ -109,7 +109,7 @@ static void decrypt_update(gimli_state *g, unsigned char *m,
 void gimli_aead_decrypt_update(gimli_state *g, unsigned char *m,
                                const unsigned char *c, size_t len)
 {
-#if (LITH_ABSORB_WORDS)
+#if (LITH_SPONGE_WORDS)
     const size_t first_block_len = (GIMLI_RATE - g->offset) % GIMLI_RATE;
     if (len >= GIMLI_RATE + first_block_len)
     {
@@ -119,7 +119,7 @@ void gimli_aead_decrypt_update(gimli_state *g, unsigned char *m,
         len -= first_block_len;
         do
         {
-#if (LITH_VECTORIZE)
+#if (LITH_SPONGE_VECTORS)
             typedef uint32_t block_t
                 __attribute__((vector_size(16), aligned(1)));
             *(block_t *)m = *(block_t *)g->state ^ *(const block_t *)c;

--- a/src/gimli_common.c
+++ b/src/gimli_common.c
@@ -85,7 +85,7 @@ static void absorb(gimli_state *g, const unsigned char *m, size_t len)
 
 void gimli_absorb(gimli_state *g, const unsigned char *m, size_t len)
 {
-#if (LITH_ABSORB_WORDS)
+#if (LITH_SPONGE_WORDS)
     const size_t first_block_len = (GIMLI_RATE - g->offset) % GIMLI_RATE;
     if (len >= GIMLI_RATE + first_block_len)
     {
@@ -94,7 +94,7 @@ void gimli_absorb(gimli_state *g, const unsigned char *m, size_t len)
         len -= first_block_len;
         do
         {
-#if (LITH_VECTORIZE)
+#if (LITH_SPONGE_VECTORS)
             typedef uint32_t block_t
                 __attribute__((vector_size(16), aligned(1)));
             *(block_t *)g->state ^= *(const block_t *)m;

--- a/src/opt.h
+++ b/src/opt.h
@@ -23,10 +23,11 @@
 #endif
 
 /*
- * If a Gimli state word fits in a machine register, absorb a word at a time.
+ * If a Gimli state word fits in a machine register, sponge operations can
+ * happen a word at a time.
  */
-#ifndef LITH_ABSORB_WORDS
-#define LITH_ABSORB_WORDS (UINT_MAX >= UINT32_MAX)
+#ifndef LITH_SPONGE_WORDS
+#define LITH_SPONGE_WORDS (UINT_MAX >= UINT32_MAX)
 #endif
 
 /*
@@ -37,14 +38,27 @@
 /* Clang claims a GNUC version of 4.2.1, so check the clang version first. */
 #if ((defined(__clang__) && (__clang_major__ >= 4)) ||                         \
      (((__GNUC__ * 100) + __GNUC_MINOR__) >= 407)) &&                          \
-    ((defined(__SSE__) && defined(__SSE2__)) ||                                \
-     (defined(__ARM_NEON) && defined(__ARM_FEATURE_UNALIGNED)))
+    ((defined(__SSE__) && defined(__SSE2__)) || (defined(__ARM_NEON)))
+
 #define LITH_VECTORIZE 1
+
+/*
+ * If vector loads from unaligned addresses are supported, sponge operations can
+ * be vectorized. This requires SSE2 on x86 and unaligned accesses on ARM.
+ */
+#if defined(__SSE2__) || defined(__ARM_FEATURE_UNALIGNED)
+#define LITH_SPONGE_VECTORS 1
+#endif
+
 #endif
 #endif
 
 #ifndef LITH_VECTORIZE
 #define LITH_VECTORIZE 0
+#endif
+
+#ifndef LITH_SPONGE_VECTORS
+#define LITH_SPONGE_VECTORS 0
 #endif
 
 /*


### PR DESCRIPTION
don't require ARM unaligned accesses for vectorized gimli
