### PR TITLE
make TrustInSoft entrypoints for other interfaces

### DIFF
--- a/.trustinsoft/SConscript
+++ b/.trustinsoft/SConscript
@@ -1,0 +1,10 @@
+Import("env")
+
+tis_env = env.Clone()
+tis_env.Append(CPPPATH="stubs")
+
+tis_env.Program("hash.c")
+tis_env.Program("x25519.c")
+tis_env.Program("keygen.c")
+tis_env.Program("sign.c")
+tis_env.Program("verify.c")

--- a/.trustinsoft/base.json
+++ b/.trustinsoft/base.json
@@ -2,11 +2,14 @@
     "files": [
         "../src/fe.c",
         "../src/gimli.c",
+        "../src/gimli_aead.c",
         "../src/gimli_common.c",
         "../src/gimli_hash.c",
         "../src/sign.c",
-        "../src/x25519.c",
-        "unknown_random.c"
+        "../src/x25519.c"
     ],
-    "cpp-extra-args": "-I../include -DLITH_VECTORIZE=0 -DLITH_LITTLE_ENDIAN=0 -DLITH_X25519_WBITS=32"
+    "cpp-extra-args": "-I../include -DLITH_VECTORIZE=0 -DLITH_LITTLE_ENDIAN=0 -DLITH_X25519_WBITS=32",
+    "val-profile": "analyzer",
+    "no-results": true,
+    "slevel": 1024
 }

--- a/.trustinsoft/config.json
+++ b/.trustinsoft/config.json
@@ -1,22 +1,27 @@
 [
     {
+        "name": "Hash",
+        "include": "base.json",
+        "files": ["hash.c"]
+    },
+    {
+        "name": "X25519",
+        "include": "base.json",
+        "files": ["x25519.c"]
+    },
+    {
+        "name": "Keygen",
+        "include": "base.json",
+        "files": ["keygen.c"]
+    },
+    {
         "name": "Sign",
         "include": "base.json",
-        "val-profile": "analyzer",
-        "no-results": true,
-        "slevel": 1024,
-        "files": [
-            "sign.c"
-        ]
+        "files": ["sign.c"]
     },
     {
         "name": "Verify",
         "include": "base.json",
-        "val-profile": "analyzer",
-        "no-results": true,
-        "slevel": 1024,
-        "files": [
-            "verify.c"
-        ]
+        "files": ["verify.c"]
     }
 ]

--- a/.trustinsoft/hash.c
+++ b/.trustinsoft/hash.c
@@ -1,0 +1,12 @@
+#include <lithium/gimli_hash.h>
+
+#include <tis_builtin.h>
+
+int main(void)
+{
+    unsigned char h[1024], m[1024];
+    tis_make_unknown(m, sizeof m);
+    size_t hlen = tis_unsigned_long_interval(0, sizeof h);
+    size_t mlen = tis_unsigned_long_interval(0, sizeof m);
+    gimli_hash(h, hlen, m, mlen);
+}

--- a/.trustinsoft/keygen.c
+++ b/.trustinsoft/keygen.c
@@ -1,0 +1,15 @@
+#include <lithium/sign.h>
+
+#include <tis_builtin.h>
+
+void lith_random_bytes(unsigned char *buf, size_t len)
+{
+    tis_make_unknown(buf, len);
+}
+
+int main(void)
+{
+    unsigned char public_key[LITH_SIGN_PUBLIC_KEY_LEN],
+        secret_key[LITH_SIGN_SECRET_KEY_LEN];
+    lith_sign_keygen(public_key, secret_key);
+}

--- a/.trustinsoft/sign.c
+++ b/.trustinsoft/sign.c
@@ -1,14 +1,13 @@
-#include <lithium/random.h>
 #include <lithium/sign.h>
 
 #include <tis_builtin.h>
 
 int main(void)
 {
-    unsigned char public_key[LITH_SIGN_PUBLIC_KEY_LEN],
-        secret_key[LITH_SIGN_SECRET_KEY_LEN], sig[LITH_SIGN_LEN], msg[1024];
-    lith_sign_keygen(public_key, secret_key);
-    lith_random_bytes(msg, sizeof msg);
+    unsigned char sig[LITH_SIGN_LEN], msg[1024],
+        secret_key[LITH_SIGN_SECRET_KEY_LEN];
+    tis_make_unknown(msg, sizeof msg);
+    tis_make_unknown(secret_key, sizeof secret_key);
     size_t msglen = tis_unsigned_long_interval(0, sizeof msg);
     lith_sign_create(sig, msg, msglen, secret_key);
 }

--- a/.trustinsoft/stubs/tis_builtin.h
+++ b/.trustinsoft/stubs/tis_builtin.h
@@ -1,0 +1,27 @@
+#ifndef STUBS_TIS_BUILTIN_H
+#define STUBS_TIS_BUILTIN_H
+
+#include <lithium/random.h>
+
+/*
+ * Trivial versions of tis_builtin.h functions that the examples use, that use
+ * random data rather than data generalization.
+ */
+
+static inline int tis_make_unknown(void *p, unsigned long len)
+{
+    lith_random_bytes(p, len);
+    return 0;
+}
+
+static inline unsigned long tis_unsigned_long_interval(unsigned long min_,
+                                                       unsigned long max_)
+{
+    unsigned long range = max_ - min_;
+    unsigned long rand;
+    lith_random_bytes((unsigned char *)&rand, sizeof rand);
+    rand %= range;
+    return min_ + range;
+}
+
+#endif // STUBS_TIS_BUILTIN_H

--- a/.trustinsoft/unknown_random.c
+++ b/.trustinsoft/unknown_random.c
@@ -1,8 +1,0 @@
-#include <lithium/random.h>
-
-#include <tis_builtin.h>
-
-void lith_random_bytes(unsigned char *buf, size_t len)
-{
-    tis_make_unknown(buf, len);
-}

--- a/.trustinsoft/verify.c
+++ b/.trustinsoft/verify.c
@@ -1,15 +1,14 @@
-#include <lithium/random.h>
 #include <lithium/sign.h>
 
 #include <tis_builtin.h>
 
 int main(void)
 {
-    unsigned char public_key[LITH_SIGN_PUBLIC_KEY_LEN],
-        secret_key[LITH_SIGN_SECRET_KEY_LEN], sig[LITH_SIGN_LEN], msg[1024];
+    unsigned char sig[LITH_SIGN_LEN], msg[1024],
+        public_key[LITH_SIGN_PUBLIC_KEY_LEN];
+    tis_make_unknown(sig, sizeof sig);
+    tis_make_unknown(msg, sizeof msg);
+    tis_make_unknown(public_key, sizeof public_key);
     size_t msglen = tis_unsigned_long_interval(0, sizeof msg);
-    lith_sign_keygen(public_key, secret_key);
-    lith_random_bytes(msg, sizeof msg);
-    lith_random_bytes(sig, sizeof sig);
     return !lith_sign_verify(sig, msg, msglen, public_key);
 }

--- a/.trustinsoft/x25519.c
+++ b/.trustinsoft/x25519.c
@@ -1,0 +1,11 @@
+#include <lithium/x25519.h>
+
+#include <tis_builtin.h>
+
+int main(void)
+{
+    unsigned char out[X25519_LEN], scalar[X25519_LEN], point[X25519_LEN];
+    tis_make_unknown(scalar, sizeof scalar);
+    tis_make_unknown(point, sizeof point);
+    x25519(out, scalar, point);
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![TrustInSoft CI](https://ci.trust-in-soft.com/projects/teslamotors/liblithium.svg?branch=main)](https://ci.trust-in-soft.com/projects/teslamotors/liblithium)
+
 ![Lithium](lithium.svg)
 
 # liblithium

--- a/SConstruct
+++ b/SConstruct
@@ -96,6 +96,7 @@ def build_with_env(path, env, test=True, measure_size=False):
                 "$SIZE $SOURCES",
             )
         )
+    return lith_env
 
 
 if platform.system() == "Windows":
@@ -233,7 +234,13 @@ else:
 
 host_env.Append(CCFLAGS=arch_flag, LINKFLAGS=arch_flag)
 
-build_with_env("dist", host_env)
+lith_env = build_with_env("dist", host_env)
+SConscript(
+    dirs=".trustinsoft",
+    variant_dir="dist/trustinsoft",
+    exports={"env": lith_env},
+    duplicate=False,
+)
 
 env16 = host_env.Clone()
 env16.Append(CPPDEFINES={"LITH_X25519_WBITS": 16})

--- a/examples/gimli-hash.c
+++ b/examples/gimli-hash.c
@@ -16,22 +16,22 @@ static ssize_t hash_fd(int fd)
     gimli_hash_state state;
     gimli_hash_init(&state);
 
-    static unsigned char buf[4096];
+    static unsigned char m[4096];
     ssize_t nread;
 
-    while ((nread = read(fd, buf, sizeof buf)) > 0)
+    while ((nread = read(fd, m, sizeof m)) > 0)
     {
-        gimli_hash_update(&state, buf, (size_t)nread);
+        gimli_hash_update(&state, m, (size_t)nread);
     }
 
     if (nread == 0)
     {
-        unsigned char output[GIMLI_HASH_DEFAULT_LEN];
-        gimli_hash_final(&state, output, sizeof output);
+        unsigned char h[GIMLI_HASH_DEFAULT_LEN];
+        gimli_hash_final(&state, h, sizeof h);
 
-        for (size_t i = 0; i < sizeof output; ++i)
+        for (size_t i = 0; i < sizeof h; ++i)
         {
-            printf("%02hhx", output[i]);
+            printf("%02hhx", h[i]);
         }
     }
 

--- a/examples/lith-sign.c
+++ b/examples/lith-sign.c
@@ -59,12 +59,12 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    static unsigned char buf[4096];
+    static unsigned char msg[4096];
     ssize_t nread;
 
-    while ((nread = read(msgfd, buf, sizeof buf)) > 0)
+    while ((nread = read(msgfd, msg, sizeof msg)) > 0)
     {
-        lith_sign_update(&state, buf, (size_t)nread);
+        lith_sign_update(&state, msg, (size_t)nread);
     }
 
     if (nread < 0)

--- a/examples/lith-verify.c
+++ b/examples/lith-verify.c
@@ -65,12 +65,12 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    static unsigned char buf[4096];
+    static unsigned char msg[4096];
     ssize_t nread;
 
-    while ((nread = read(msgfd, buf, sizeof buf)) > 0)
+    while ((nread = read(msgfd, msg, sizeof msg)) > 0)
     {
-        lith_sign_update(&state, buf, (size_t)nread);
+        lith_sign_update(&state, msg, (size_t)nread);
     }
 
     if (nread < 0)

--- a/hydro/examples/hydro-hash.c
+++ b/hydro/examples/hydro-hash.c
@@ -11,22 +11,22 @@ static ssize_t hash_fd(int fd)
     static const char ctx[hydro_hash_CONTEXTBYTES] = {0};
     hydro_hash_init(&state, ctx, NULL);
 
-    static unsigned char buf[4096];
+    static unsigned char m[4096];
     ssize_t nread;
 
-    while ((nread = read(fd, buf, sizeof buf)) > 0)
+    while ((nread = read(fd, m, sizeof m)) > 0)
     {
-        hydro_hash_update(&state, buf, (size_t)nread);
+        hydro_hash_update(&state, m, (size_t)nread);
     }
 
     if (nread == 0)
     {
-        unsigned char output[hydro_hash_BYTES];
-        hydro_hash_final(&state, output, sizeof output);
+        unsigned char h[hydro_hash_BYTES];
+        hydro_hash_final(&state, h, sizeof h);
 
-        for (size_t i = 0; i < sizeof output; ++i)
+        for (size_t i = 0; i < sizeof h; ++i)
         {
-            printf("%02hhx", output[i]);
+            printf("%02hhx", h[i]);
         }
     }
 

--- a/hydro/examples/hydro-sign.c
+++ b/hydro/examples/hydro-sign.c
@@ -54,12 +54,12 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    static unsigned char buf[4096];
+    static unsigned char msg[4096];
     ssize_t nread;
 
-    while ((nread = read(msgfd, buf, sizeof buf)) > 0)
+    while ((nread = read(msgfd, msg, sizeof msg)) > 0)
     {
-        hydro_sign_update(&state, buf, (size_t)nread);
+        hydro_sign_update(&state, msg, (size_t)nread);
     }
 
     if (nread < 0)

--- a/hydro/examples/hydro-verify.c
+++ b/hydro/examples/hydro-verify.c
@@ -54,12 +54,12 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    static unsigned char buf[4096];
+    static unsigned char msg[4096];
     ssize_t nread;
 
-    while ((nread = read(msgfd, buf, sizeof buf)) > 0)
+    while ((nread = read(msgfd, msg, sizeof msg)) > 0)
     {
-        hydro_sign_update(&state, buf, (size_t)nread);
+        hydro_sign_update(&state, msg, (size_t)nread);
     }
 
     if (nread < 0)

--- a/include/lithium/gimli_aead.h
+++ b/include/lithium/gimli_aead.h
@@ -19,28 +19,29 @@ void gimli_aead_init(gimli_state *g,
                      const unsigned char n[GIMLI_AEAD_NONCE_LEN],
                      const unsigned char k[GIMLI_AEAD_KEY_LEN]);
 
-void gimli_aead_update_ad(gimli_state *g, const unsigned char *ad, size_t len);
+void gimli_aead_update_ad(gimli_state *g, const unsigned char *ad,
+                          size_t adlen);
 
 void gimli_aead_final_ad(gimli_state *g);
 
 void gimli_aead_encrypt_update(gimli_state *g, unsigned char *c,
                                const unsigned char *m, size_t len);
 
-void gimli_aead_encrypt_final(gimli_state *g, unsigned char *t, size_t len);
+void gimli_aead_encrypt_final(gimli_state *g, unsigned char *t, size_t tlen);
 
 void gimli_aead_decrypt_update(gimli_state *g, unsigned char *m,
                                const unsigned char *c, size_t len);
 
 bool gimli_aead_decrypt_final(gimli_state *g, const unsigned char *t,
-                              size_t len);
+                              size_t tlen);
 
 void gimli_aead_encrypt(unsigned char *c, unsigned char *t, size_t tlen,
-                        const unsigned char *m, size_t mlen,
+                        const unsigned char *m, size_t len,
                         const unsigned char *ad, size_t adlen,
                         const unsigned char n[GIMLI_AEAD_NONCE_LEN],
                         const unsigned char k[GIMLI_AEAD_KEY_LEN]);
 
-bool gimli_aead_decrypt(unsigned char *m, const unsigned char *c, size_t clen,
+bool gimli_aead_decrypt(unsigned char *m, const unsigned char *c, size_t len,
                         const unsigned char *t, size_t tlen,
                         const unsigned char *ad, size_t adlen,
                         const unsigned char n[GIMLI_AEAD_NONCE_LEN],

--- a/include/lithium/gimli_hash.h
+++ b/include/lithium/gimli_hash.h
@@ -18,13 +18,12 @@ typedef gimli_state gimli_hash_state;
 
 void gimli_hash_init(gimli_hash_state *g);
 
-void gimli_hash_update(gimli_hash_state *g, const unsigned char *input,
-                       size_t len);
+void gimli_hash_update(gimli_hash_state *g, const unsigned char *m, size_t len);
 
-void gimli_hash_final(gimli_hash_state *g, unsigned char *output, size_t len);
+void gimli_hash_final(gimli_hash_state *g, unsigned char *h, size_t len);
 
-void gimli_hash(unsigned char *output, size_t output_len,
-                const unsigned char *input, size_t input_len);
+void gimli_hash(unsigned char *h, size_t hlen, const unsigned char *m,
+                size_t mlen);
 
 /* cffi:end */
 

--- a/src/gimli_common.c
+++ b/src/gimli_common.c
@@ -70,8 +70,7 @@ static void absorb(uint32_t *state, size_t *offset, const unsigned char *m,
     }
 }
 
-void gimli_absorb(gimli_state *g, const unsigned char *m,
-                  size_t len)
+void gimli_absorb(gimli_state *g, const unsigned char *m, size_t len)
 {
     size_t offset = g->offset;
 #if (LITH_SPONGE_WORDS)


### PR DESCRIPTION
update parameters in gimli_hash.h and gimli_aead.h

update example variable names to more closely match interfaces
