### PR TITLE
improvements

### DIFF
--- a/scripts/test_hydro.bash
+++ b/scripts/test_hydro.bash
@@ -25,8 +25,8 @@ else
     git clone https://github.com/jedisct1/libhydrogen.git
 fi
 
-if [[ "$(uname -ps)" == "Darwin arm" ]]; then
-    arch_flag="-mcpu=apple-a14"
+if [[ "$(uname -p)" =~ arm|aarch64 ]]; then
+    arch_flag="-march=armv8.4-a"
 else
     arch_flag="-march=native"
 fi
@@ -59,12 +59,12 @@ $CC $CCFLAGS -c -o arm_hydrogen.o libhydrogen/hydrogen.c
 $CC $CCFLAGS -Wl,--entry=hydro_sign_verify -o libhydrogen_sign_verify arm_hydrogen.o
 $CC $CCFLAGS -Wl,--entry=hydro_hash_hash -o libhydrogen_hash_hash arm_hydrogen.o
 
-scons -C ../../.. --no-sanitize --jobs "$(nproc)" dist/arm/entrypoints
+scons -C ../../.. --no-sanitize --jobs "$(nproc)" dist/arm-eabi/entrypoints
 
 arm-none-eabi-size \
   libhydrogen_sign_verify \
-  ../../arm/entrypoints/hydro_sign_verify \
-  ../../arm/entrypoints/lith_sign_verify \
+  ../../arm-eabi/entrypoints/hydro_sign_verify \
+  ../../arm-eabi/entrypoints/lith_sign_verify \
   libhydrogen_hash_hash \
-  ../../arm/entrypoints/hydro_hash_hash \
-  ../../arm/entrypoints/gimli_hash
+  ../../arm-eabi/entrypoints/hydro_hash_hash \
+  ../../arm-eabi/entrypoints/gimli_hash

--- a/src/gimli.c
+++ b/src/gimli.c
@@ -87,7 +87,7 @@ static void swap(uint32_t *x, int i, int j)
     x[j] = tmp;
 }
 
-void gimli(uint32_t *state)
+void gimli(uint32_t state[GIMLI_WORDS])
 {
     int round;
     for (round = 24; round > 0; --round)

--- a/src/gimli_aead.c
+++ b/src/gimli_aead.c
@@ -170,7 +170,7 @@ bool gimli_aead_decrypt_final(gimli_state *g, const unsigned char *t,
         gimli_advance(g->state, &offset);
         mismatch |= t[i] ^ gimli_squeeze_byte(g->state, offset);
     }
-    return !mismatch;
+    return mismatch == 0;
 }
 
 void gimli_aead_encrypt(unsigned char *c, unsigned char *t, size_t tlen,
@@ -202,7 +202,7 @@ bool gimli_aead_decrypt(unsigned char *m, const unsigned char *c, size_t len,
     gimli_aead_final_ad(&g);
     gimli_aead_decrypt_update(&g, m, c, len);
     success = gimli_aead_decrypt_final(&g, t, tlen);
-    mask = (unsigned char)~(((uint32_t)success - 1) >> 16);
+    mask = (unsigned char)(~(unsigned int)success + 1);
     for (i = 0; i < len; ++i)
     {
         m[i] &= mask;

--- a/src/x25519.c
+++ b/src/x25519.c
@@ -122,6 +122,17 @@ void x25519(unsigned char out[X25519_LEN],
     fe x;
     feq P;
     read_limbs(x, point);
+    /*
+     * Per RFC7748 section 5:
+     * "When receiving such an array, implementations of X25519 (but not X448)
+     * MUST mask the most significant bit in the final byte. This is done to
+     * preserve compatibility with point formats that reserve the sign bit for
+     * use in other protocols and to increase resistance to implementation
+     * fingerprinting."
+     *
+     * Clear this bit after converting to an fe to avoid making an extra copy.
+     */
+    x[NLIMBS - 1] &= ~((limb)1 << (LITH_X25519_WBITS - 1));
     x25519_q(P, scalar, x);
     inv(Z(P));
     mul1(X(P), Z(P));


### PR DESCRIPTION
- fix non-vectorized gimli prototype to also use GIMLI_WORDS
- clear the high bit of the input point in x25519 to be compatible with rfc7748
- simplify aead decrypt masking
- use A and B for left and right of verify equation instead of Z(P) and Z(Q)
- fix up build scripts to work on Linux aarch64
