### PR TITLE
python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install -qq --upgrade pip
-        python -m pip install -qq black
+        python -m pip install -qq black==21.12b0
     - name: Format with black
       run: |
         bash black-check.bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2019]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install -qq --upgrade pip


### PR DESCRIPTION
- update github workflow to also build against python3.10
- pin to black 21.12b0 to avoid failures if the formatting were to change
