### PR TITLE
uniform reduce

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -182,7 +182,7 @@ separate copyright notice and license terms. Your use of liblithium is subject
 to the terms and conditions of STROBE's MIT license, in addition to
 liblithium's Apache 2.0 license.
 
-The STROBE project is available here: https://strobe.sourceforge.io/
+The STROBE project is available here: https://strobe.sourceforge.io
 
 The STROBE license is reproduced below:
 
@@ -207,3 +207,34 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+The implementation of lith_memzero is derived from the musl libc project, which
+has a separate copyright notice and license terms. Your use of liblithium is
+subject to the terms and conditions of musl's MIT license, in addition to
+liblithium's Apache 2.0 license.
+
+The musl libc project is available here: https://musl.libc.org
+
+The musl libc license is reproduced below:
+
+Copyright © 2005-2020 Rich Felker, et al.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ffibuilder.py
+++ b/ffibuilder.py
@@ -19,6 +19,7 @@ ffibuilder.set_source(
         "src/gimli_common.c",
         "src/gimli_hash.c",
         "src/fe.c",
+        "src/memzero.c",
         "src/x25519.c",
         "src/sign.c",
     ],

--- a/hydro/hydrogen.c
+++ b/hydro/hydrogen.c
@@ -104,7 +104,7 @@ int hydro_hash_hash(uint8_t *out, size_t out_len, const void *in_,
 void hydro_sign_keygen(hydro_sign_keypair *kp)
 {
     hydro_random_buf(kp->sk, X25519_LEN);
-    x25519_base(kp->pk, kp->sk);
+    x25519_base_uniform(kp->pk, kp->sk);
     memcpy(&kp->sk[X25519_LEN], kp->pk, X25519_LEN);
 }
 
@@ -152,7 +152,7 @@ int hydro_sign_final_create(hydro_sign_state *state,
     hydro_hash_update(&st, prehash, hydro_sign_PREHASHBYTES);
     hydro_hash_final(&st, eph_sk, X25519_LEN);
 
-    x25519_base(nonce, eph_sk);
+    x25519_base_uniform(nonce, eph_sk);
     hydro_sign_challenge(challenge, nonce, pk, prehash);
 
     x25519_sign(sig, challenge, eph_sk, sk);

--- a/include/lithium/x25519.h
+++ b/include/lithium/x25519.h
@@ -16,14 +16,9 @@
 #define X25519_LEN (X25519_BITS / 8)
 
 /*
- * Clamp an arbitrary 256 bit value to be a legal x25519 scalar.
- */
-void x25519_clamp(unsigned char scalar[X25519_LEN]);
-
-/*
  * x25519 scalar multiplication. Sets out to scalar*point.
  *
- * scalar should be clamped like a Curve25519 secret key.
+ * scalar will be clamped internally per RFC7748.
  */
 void x25519(unsigned char out[X25519_LEN],
             const unsigned char scalar[X25519_LEN],
@@ -32,25 +27,41 @@ void x25519(unsigned char out[X25519_LEN],
 /*
  * Scalar multiplication of the curve's base point.
  *
- * scalar should be clamped like a Curve25519 secret key.
+ * scalar will be clamped internally per RFC7748.
  */
 void x25519_base(unsigned char out[X25519_LEN],
                  const unsigned char scalar[X25519_LEN]);
 
 /*
- * STROBE-compatible Schnorr signatures using curve25519 (not ed25519).
+ * Reduce a 512-bit scalar s mod L, the prime subgroup order.
+ * Store the result in r. s and r may alias.
+ */
+void x25519_scalar_reduce(unsigned char r[X25519_LEN],
+                          const unsigned char s[X25519_LEN * 2]);
+
+/*
+ * Scalar multiplication of the curve's base point by a scalar which is
+ * uniformly-distributed mod L, the prime subgroup order.
+ */
+void x25519_base_uniform(unsigned char out[X25519_LEN],
+                         const unsigned char scalar[X25519_LEN]);
+
+/*
+ * Schnorr signatures using Curve25519 (not ed25519).
  *
- * The user will call x25519_base(public_nonce, secret_nonce) to schedule a
- * random ephemeral secret key. They then call a Schnorr oracle to get a
- * challenge, and compute the response using this function.
+ * The user will call x25519_base_uniform(public_nonce, secret_nonce) to
+ * schedule a random ephemeral secret key. They then call a Schnorr oracle to
+ * get a challenge, and compute the response using this function.
+ *
+ * challenge and secret_nonce should be uniform mod L.
  */
 void x25519_sign(unsigned char response[X25519_LEN],
                  const unsigned char challenge[X25519_LEN],
                  const unsigned char secret_nonce[X25519_LEN],
-                 const unsigned char secret_key[X25519_LEN]);
+                 const unsigned char secret_scalar[X25519_LEN]);
 
 /*
- * STROBE-compatible signature verification using curve25519 (not ed25519).
+ * Signature verification using Curve25519 (not ed25519).
  * This function is the public equivalent x25519_sign, taking the long-term
  * and ephemeral public keys instead of secret ones.
  *

--- a/src/SConscript
+++ b/src/SConscript
@@ -5,13 +5,14 @@ Import("env")
 liblithium = env.StaticLibrary(
     target="lithium",
     source=[
-        "gimli.c",
-        "gimli_common.c",
-        "gimli_hash.c",
-        "gimli_aead.c",
         "fe.c",
-        "x25519.c",
+        "gimli.c",
+        "gimli_aead.c",
+        "gimli_hash.c",
+        "gimli_common.c",
+        "memzero.c",
         "sign.c",
+        "x25519.c",
     ],
 )
 

--- a/src/fe.c
+++ b/src/fe.c
@@ -72,7 +72,7 @@ static void propagate(fe x, limb carry)
     carry <<= 1;
     carry |= x[NLIMBS - 1] >> (LITH_X25519_WBITS - 1);
     carry *= 19;
-    x[NLIMBS - 1] &= ~((limb)1 << (LITH_X25519_WBITS - 1));
+    x[NLIMBS - 1] &= ~LIMB_HIGH_BIT_MASK;
     for (i = 0; i < NLIMBS; ++i)
     {
         x[i] = adc(&carry, x[i], 0);

--- a/src/fe.h
+++ b/src/fe.h
@@ -57,6 +57,8 @@ typedef __int128_t sdlimb;
 
 #define NLIMBS (X25519_BITS / LITH_X25519_WBITS)
 
+#define LIMB_HIGH_BIT_MASK ((limb)1U << (LITH_X25519_WBITS - 1))
+
 typedef limb fe[NLIMBS];
 
 void read_limbs(limb x[NLIMBS], const unsigned char *in);

--- a/src/memzero.c
+++ b/src/memzero.c
@@ -1,0 +1,70 @@
+/*
+ * Part of liblithium, under the Apache License v2.0.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Derived from musl libc's explicit_bzero.c, under the MIT license.
+ * musl libc is Copyright © 2005-2020 Rich Felker, et al.
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "memzero.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+
+#include <wincrypt.h>
+#elif defined(__GNUC__) || defined(__clang__)
+#include <string.h>
+#endif
+
+void lith_memzero(void *p, size_t len)
+{
+#if defined(_WIN32)
+    SecureZeroMemory(p, len);
+#elif defined(__GNUC__) || defined(__clang__)
+    /*
+     * Derived from musl libc's implementation of explicit_bzero.
+     *
+     * See these emails from Rich Felker for an explanation.
+     * https://www.openwall.com/lists/musl/2015/01/29/3
+     * https://www.openwall.com/lists/musl/2018/06/28/9
+     * https://www.openwall.com/lists/musl/2018/06/28/11
+     *
+     * "As long as there's a barrier, LTO is no problem. The asm is a black
+     * box that's required to see the results of memset, since the address of
+     * the object reaches the asm, and the only way to ensure that such a black
+     * box sees the writes is for them to actually be performed."
+     */
+    __asm__ __volatile__("" : : "r"(memset(p, 0, len)) : "memory");
+#else
+    /*
+     * Fall back to writing through a volatile pointer if nothing else is
+     * available.
+     *
+     * See this post about why this approach is not guaranteed to work:
+     * https://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
+     *
+     * "The C standard states that accesses to volatile objects are part of the
+     * unalterable observable behaviour — but it says nothing about accesses
+     * via lvalue expressions with volatile types. Consequently a sufficiently
+     * intelligent compiler can still optimize the buffer-zeroing away in this
+     * case — it just has to prove that the object being accessed was not
+     * originally defined as being volatile.
+     *
+     * Some people will try this with secure_memzero in a separate C file. This
+     * will trick yet more compilers, but no guarantees — with link-time
+     * optimization the compiler may still discover your treachery."
+     *
+     * We'll treat it as good enough if we're on a platform that doesn't
+     * support the inline assembly statement required to prevent optimization.
+     * Such compilers are hopefully not devious enough to optimize this away,
+     * or don't have LTO.
+     */
+    volatile unsigned char *pv = p;
+    size_t i;
+    for (i = 0; i < len; ++i)
+    {
+        pv[i] = 0;
+    }
+#endif
+}

--- a/src/memzero.h
+++ b/src/memzero.h
@@ -1,0 +1,13 @@
+/*
+ * Part of liblithium, under the Apache License v2.0.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LITHIUM_MEMZERO_H
+#define LITHIUM_MEMZERO_H
+
+#include <stddef.h>
+
+void lith_memzero(void *p, size_t n);
+
+#endif /* LITHIUM_MEMZERO_H */

--- a/src/sign.c
+++ b/src/sign.c
@@ -8,6 +8,8 @@
 #include <lithium/random.h>
 #include <lithium/x25519.h>
 
+#include "memzero.h"
+
 #include <string.h>
 
 void lith_sign_keygen(unsigned char public_key[LITH_SIGN_PUBLIC_KEY_LEN],
@@ -18,6 +20,7 @@ void lith_sign_keygen(unsigned char public_key[LITH_SIGN_PUBLIC_KEY_LEN],
     gimli_hash(secret_scalar, X25519_LEN, secret_key, X25519_LEN);
     x25519_base_uniform(public_key, secret_scalar);
     (void)memcpy(&secret_key[X25519_LEN], public_key, X25519_LEN);
+    lith_memzero(secret_scalar, X25519_LEN);
 }
 
 void lith_sign_init(lith_sign_state *state)
@@ -84,6 +87,7 @@ void lith_sign_create_from_prehash(
     gen_challenge(&state, challenge, public_nonce, public_key, prehash);
 
     x25519_sign(response, challenge, secret_nonce, secret_scalar);
+    lith_memzero(secret_scalar, X25519_LEN);
 }
 
 void lith_sign_final_prehash(lith_sign_state *state,

--- a/src/x25519.c
+++ b/src/x25519.c
@@ -86,26 +86,29 @@ static void x25519_q(feq P, const sc k, const fe x)
 {
     feq Q;
     limb swap = 0;
-    int i;
+    int i, j;
     (void)memcpy(X(Q), x, sizeof(fe));
     (void)memset(Z(Q), 0, sizeof(fe));
     (void)memset(P, 0, sizeof(feq));
     Z(Q)[0] = 1;
     X(P)[0] = 1;
 
-    for (i = X25519_BITS - 1; i >= 0; --i)
+    for (i = NLIMBS - 1; i >= 0; --i)
     {
-        fe t;
-        const limb ki =
-            ~((k[i / LITH_X25519_WBITS] >> (i % LITH_X25519_WBITS)) & 1) + 1;
-        cswap(swap ^ ki, P, Q);
-        swap = ki;
-        ladder_part1(P, Q, t);
-        ladder_part2(P, Q, t, x);
+        for (j = LITH_X25519_WBITS - 1; j >= 0; --j)
+        {
+            fe t;
+            const limb kb = ~((k[i] >> j) & 1) + 1;
+            cswap(swap ^ kb, P, Q);
+            swap = kb;
+            ladder_part1(P, Q, t);
+            ladder_part2(P, Q, t, x);
 #if (LITH_ENABLE_WATCHDOG)
-        lith_watchdog_pet();
+            lith_watchdog_pet();
 #endif
+        }
     }
+
     cswap(swap, P, Q);
 }
 

--- a/src/x25519.c
+++ b/src/x25519.c
@@ -98,7 +98,7 @@ static void x25519_q(feq P, const sc k, const fe x)
         for (j = LITH_X25519_WBITS - 1; j >= 0; --j)
         {
             fe t;
-            const limb kb = ~((k[i] >> j) & 1) + 1;
+            const limb kb = (limb)0 - ((k[i] >> j) & 1);
             cswap(swap ^ kb, P, Q);
             swap = kb;
             ladder_part1(P, Q, t);

--- a/src/x25519.c
+++ b/src/x25519.c
@@ -82,7 +82,7 @@ static void ladder_part2(feq P, feq Q, const fe t, const fe x)
     mul1(X(P), t);      /* X(P) = AABB */
 }
 
-static void x25519_q(feq P, const unsigned char k[X25519_LEN], const fe x)
+static void x25519_q(feq P, const sc k, const fe x)
 {
     feq Q;
     limb swap = 0;
@@ -95,8 +95,9 @@ static void x25519_q(feq P, const unsigned char k[X25519_LEN], const fe x)
 
     for (i = X25519_BITS - 1; i >= 0; --i)
     {
-        const limb ki = ~(((limb)k[i / 8] >> (i % 8)) & 1) + 1;
         fe t;
+        const limb ki =
+            ~((k[i / LITH_X25519_WBITS] >> (i % LITH_X25519_WBITS)) & 1) + 1;
         cswap(swap ^ ki, P, Q);
         swap = ki;
         ladder_part1(P, Q, t);
@@ -108,20 +109,22 @@ static void x25519_q(feq P, const unsigned char k[X25519_LEN], const fe x)
     cswap(swap, P, Q);
 }
 
-void x25519_clamp(unsigned char scalar[X25519_LEN])
+static void feq_to_bytes(unsigned char out[X25519_LEN], feq P)
 {
-    scalar[0] &= 0xF8U;
-    scalar[X25519_LEN - 1] &= 0x7FU;
-    scalar[X25519_LEN - 1] |= 0x40U;
+    inv(Z(P));
+    mul1(X(P), Z(P));
+    (void)canon(X(P));
+    write_limbs(out, X(P));
 }
 
 void x25519(unsigned char out[X25519_LEN],
             const unsigned char scalar[X25519_LEN],
             const unsigned char point[X25519_LEN])
 {
-    fe x;
     feq P;
-    read_limbs(x, point);
+    fe x;
+    sc k;
+
     /*
      * Per RFC7748 section 5:
      * "When receiving such an array, implementations of X25519 (but not X448)
@@ -132,12 +135,26 @@ void x25519(unsigned char out[X25519_LEN],
      *
      * Clear this bit after converting to an fe to avoid making an extra copy.
      */
-    x[NLIMBS - 1] &= ~((limb)1 << (LITH_X25519_WBITS - 1));
-    x25519_q(P, scalar, x);
-    inv(Z(P));
-    mul1(X(P), Z(P));
-    (void)canon(X(P));
-    write_limbs(out, X(P));
+    read_limbs(x, point);
+    x[NLIMBS - 1] &= ~LIMB_HIGH_BIT_MASK;
+
+    /*
+     * Also per RFC7748 section 5:
+     * "For X25519, in order to decode 32 random bytes as an integer scalar,
+     * set the three least significant bits of the first byte and the most
+     * significant bit of the last to zero, set the second most significant bit
+     * of the last byte to 1 and, finally, decode as little-endian."
+     *
+     * Perform these bit set/clear operations after converting to an sc to
+     * avoid making an extra copy.
+     */
+    read_limbs(k, scalar);
+    k[0] &= ~(limb)0x7U;
+    k[NLIMBS - 1] &= ~LIMB_HIGH_BIT_MASK;
+    k[NLIMBS - 1] |= LIMB_HIGH_BIT_MASK >> 1;
+
+    x25519_q(P, k, x);
+    feq_to_bytes(out, P);
 }
 
 #define BASE_POINT 9U
@@ -149,60 +166,26 @@ void x25519_base(unsigned char out[X25519_LEN],
     x25519(out, scalar, base_point);
 }
 
-bool x25519_verify(const unsigned char response[X25519_LEN],
-                   const unsigned char challenge[X25519_LEN],
-                   const unsigned char public_nonce[X25519_LEN],
-                   const unsigned char public_key[X25519_LEN])
-{
-    /*
-     * See doc/verify.tex for a derivation of signature verification using only
-     * x-coordinates based on "Fast and compact elliptic-curve cryptography".
-     * https://www.shiftleft.org/papers/fff/
-     * https://eprint.iacr.org/2012/309.pdf
-     */
-    feq P, Q;
-    fe A, B = {BASE_POINT};
+static const sc L = {
+    LIMBS(0xD3ED, 0x5CF5, 0x631A, 0x5812),
+    LIMBS(0x9CD6, 0xA2F7, 0xF9DE, 0x14DE),
+    LIMBS(0x0000, 0x0000, 0x0000, 0x0000),
+    LIMBS(0x0000, 0x0000, 0x0000, 0x1000),
+};
 
-    read_limbs(A, public_key);
-    x25519_q(P, response, B);
-    x25519_q(Q, challenge, A);
-    /* P = x/z = response*base_point */
-    /* Q = u/w = challenge*public_key */
+static const sc RmodL = {
+    LIMBS(0x951D, 0x8D98, 0x3174, 0xD6EC),
+    LIMBS(0xCF70, 0x737D, 0x5BF4, 0xC6EF),
+    LIMBS(0xFFFE, 0xFFFF, 0xFFFF, 0xFFFF),
+    LIMBS(0xFFFF, 0xFFFF, 0xFFFF, 0x0FFF),
+};
 
-    mul(A, X(Q), Z(Q));
-    mul_word(A, A, 16);
-    /* A = 16uw */
-
-    ladder_part1(P, Q, B);
-    /* X(Q) = 2xu - 2zw */
-    /* Z(Q) = 2zu - 2xw */
-    /* Z(P) = xx + axz + zz */
-
-    read_limbs(B, public_nonce);
-    /* B = R */
-
-    mul1(A, Z(P));
-    mul1(A, B);
-    /* A = left = 16uwR(xx + axz + zz) */
-
-    mul1(Z(Q), B);
-    sub(B, Z(Q), X(Q));
-    sqr1(B);
-    /* B = right = (R(2zu - 2xw) - (2xu - 2zw))^2 */
-
-    /* check equality:
-     * 16uwR(xx + axz + zz) == (R(2zu - 2xw) - (2xu - 2zw))^2 */
-    sub(A, A, B);
-
-    /*
-     * If canon(A) returns nonzero, A is zero and the two sides are equal.
-     * If canon(B) also returns nonzero, then B is zero and both sides are zero.
-     *
-     * Reject signatures where both sides are zero, because that can happen if
-     * an input causes the ladder to return 0/0.
-     */
-    return (canon(A) & ~canon(B)) != 0;
-}
+static const sc R2modL = {
+    LIMBS(0x0F01, 0x449C, 0x11E3, 0xA406),
+    LIMBS(0x9347, 0x6885, 0x1BA7, 0xD00E),
+    LIMBS(0xBE65, 0x17F5, 0x73D2, 0xCEEC),
+    LIMBS(0x9A3D, 0x7C30, 0x411B, 0x0399),
+};
 
 /*
  * Montgomery factor: -L^-1 mod 2^LITH_X25519_WBITS
@@ -210,7 +193,7 @@ bool x25519_verify(const unsigned char response[X25519_LEN],
 #define MONTGOMERY_FACTOR LOW_LIMB(0x7E1B, 0x1254, 0x1DA3, 0xD2B5)
 
 /*
- * Set t = (t + ab)R^-1 mod l
+ * Set t = (t + ab)R^-1 mod L
  */
 static void sc_montmul(sc t, const sc a, const sc b)
 {
@@ -222,13 +205,6 @@ static void sc_montmul(sc t, const sc a, const sc b)
      * rid of high carry. Second montmul, by r^2 mod p < p: output < (Mp +
      * Mp)/M = 2p, subtract p, < p, done.
      */
-    static const sc L = {
-        LIMBS(0xD3ED, 0x5CF5, 0x631A, 0x5812),
-        LIMBS(0x9CD6, 0xA2F7, 0xF9DE, 0x14DE),
-        LIMBS(0x0000, 0x0000, 0x0000, 0x0000),
-        LIMBS(0x0000, 0x0000, 0x0000, 0x1000),
-    };
-
     limb hic = 0, need_add, carry, carry2, u;
     sdlimb scarry = 0;
     int i, j;
@@ -273,36 +249,144 @@ static void sc_montmul(sc t, const sc a, const sc b)
     }
 }
 
+void x25519_scalar_reduce(unsigned char r[X25519_LEN],
+                          const unsigned char s[X25519_LEN * 2])
+{
+    /*
+     * R = 2^256
+     * let a = s mod R (lower 256 bits)
+     * let b = s / R (upper 256 bits)
+     * s mod L = (a + bR) mod L
+     *
+     * sc_montmul(t, a, b) implements:
+     * t = (t + ab)R^-1 mod L
+     *
+     * sc_montmul(a, b, RmodL):
+     * a' = (a + bR)R^-1 mod L
+     *
+     * b' = 0
+     * sc_montmul(b', a', R^2):
+     * b'' = (b' + a'R^2)R^-1 mod L
+     * b'' = (0 + ((a + bR)R^-1)R^2)R^-1 mod L
+     * b'' = (a + bR) mod L
+     */
+    sc a, b;
+    read_limbs(a, &s[0]);
+    read_limbs(b, &s[X25519_LEN]);
+    sc_montmul(a, b, RmodL);
+    (void)memset(b, 0, sizeof b);
+    sc_montmul(b, a, R2modL);
+    write_limbs(r, b);
+}
+
+void x25519_base_uniform(unsigned char out[X25519_LEN],
+                         const unsigned char scalar[X25519_LEN])
+{
+    feq P;
+    fe B = {BASE_POINT};
+    sc k;
+    read_limbs(k, scalar);
+    x25519_q(P, k, B);
+    feq_to_bytes(out, P);
+}
+
+bool x25519_verify(const unsigned char response[X25519_LEN],
+                   const unsigned char challenge[X25519_LEN],
+                   const unsigned char public_nonce[X25519_LEN],
+                   const unsigned char public_key[X25519_LEN])
+{
+    /*
+     * See doc/verify.tex for a derivation of signature verification using only
+     * x-coordinates based on "Fast and compact elliptic-curve cryptography".
+     * https://www.shiftleft.org/papers/fff/
+     * https://eprint.iacr.org/2012/309.pdf
+     */
+    feq P, Q;
+    fe A, B = {BASE_POINT};
+    sc k;
+
+    read_limbs(k, response);
+    x25519_q(P, k, B);
+    /* P = x/z = response*base_point */
+
+    read_limbs(k, challenge);
+    read_limbs(A, public_key);
+    x25519_q(Q, k, A);
+    /* Q = u/w = challenge*public_key */
+
+    mul(A, X(Q), Z(Q));
+    mul_word(A, A, 16);
+    /* A = 16uw */
+
+    ladder_part1(P, Q, B);
+    /* X(Q) = 2xu - 2zw */
+    /* Z(Q) = 2zu - 2xw */
+    /* Z(P) = xx + axz + zz */
+
+    read_limbs(B, public_nonce);
+    /* B = R */
+
+    mul1(A, Z(P));
+    mul1(A, B);
+    /* A = left = 16uwR(xx + axz + zz) */
+
+    mul1(Z(Q), B);
+    sub(B, Z(Q), X(Q));
+    sqr1(B);
+    /* B = right = (R(2zu - 2xw) - (2xu - 2zw))^2 */
+
+    /* check equality:
+     * 16uwR(xx + axz + zz) == (R(2zu - 2xw) - (2xu - 2zw))^2 */
+    sub(A, A, B);
+
+    /*
+     * If canon(A) returns nonzero, then A is zero and the two sides are equal.
+     * If canon(B) also returns nonzero, then B is zero and both sides are zero.
+     *
+     * Reject signatures where both sides are zero, because that can happen if
+     * an input causes the ladder to return 0/0.
+     */
+    return (canon(A) & ~canon(B)) != 0;
+}
+
 /*
- * compute response = secret_nonce + secret_key * challenge
+ * compute response = secret_nonce + secret_scalar * challenge mod L
  *
  * verifier will check
- * response * base = (secret_nonce + secret_key * challenge) * base
- * response * base = secret_nonce * base + secret_key * challenge * base
+ * response * base = (secret_nonce + secret_scalar * challenge) * base
+ * response * base = secret_nonce * base + secret_scalar * challenge * base
  * response * base = public_nonce + challenge * public_key
  */
 void x25519_sign(unsigned char response[X25519_LEN],
                  const unsigned char challenge[X25519_LEN],
                  const unsigned char secret_nonce[X25519_LEN],
-                 const unsigned char secret_key[X25519_LEN])
+                 const unsigned char secret_scalar[X25519_LEN])
 {
     /*
      * R = 2^256
-     * Doing a Montgomery multiply by R^2 mod L undoes the Montgomery
-     * reductions.
+     * let r = secret_nonce
+     * let a = secret_scalar
+     * let h = challenge
+     *
+     * sc_montmul(t, a, b) implements:
+     * t = (t + ab)R^-1 mod L
+     *
+     * sc_montmul(r, a, h):
+     * r' = (r + ah)R^-1 mod L
+     *
+     * a' = 0
+     * sc_montmul(a', r', R^2):
+     * a'' = (a' + r'R^2)R^-1 mod L
+     * a'' = (0 + ((r + ah)R^-1)R^2)R^-1 mod L
+     * a'' = (r + ah) mod L
+     * a'' = secret_nonce + secret_scalar * challenge mod L
      */
-    static const sc R2modL = {
-        LIMBS(0x0F01, 0x449C, 0x11E3, 0xA406),
-        LIMBS(0x9347, 0x6885, 0x1BA7, 0xD00E),
-        LIMBS(0xBE65, 0x17F5, 0x73D2, 0xCEEC),
-        LIMBS(0x9A3D, 0x7C30, 0x411B, 0x0399),
-    };
     sc r, a, h;
     read_limbs(r, secret_nonce);
-    read_limbs(a, secret_key);
+    read_limbs(a, secret_scalar);
     read_limbs(h, challenge);
-    sc_montmul(r, a, h); /* r = (secret_nonce + secret_key * challenge)R^-1 */
-    (void)memset(a, 0, sizeof(sc));
-    sc_montmul(a, r, R2modL); /* a = (secret_nonce + secret_key * challenge) */
+    sc_montmul(r, a, h);
+    (void)memset(a, 0, sizeof a);
+    sc_montmul(a, r, R2modL);
     write_limbs(response, a);
 }

--- a/test/SConscript
+++ b/test/SConscript
@@ -19,10 +19,14 @@ test_kat("test_lwc_hash_kat", "LWC_HASH_KAT_256.txt")
 test_kat("test_lwc_aead_kat", "LWC_AEAD_KAT_256_128.txt")
 
 
-def test(name):
-    prog = env.Program(name + ".c")
+def test(name, extra_sources=[]):
+    prog = env.Program(target=name, source=[name + ".c"] + extra_sources)
     env.Command(target=name + ".txt", source=prog, action="$SOURCE ")
 
 
+env_ed25519 = env.Clone()
+env_ed25519.Append(CCFLAGS=["-Wno-conversion", "-fwrapv"])
+
 test("test_x25519")
 test("test_fe")
+test("test_reduce", extra_sources=[env_ed25519.Object("sc_reduce.c")])

--- a/test/sc_reduce.c
+++ b/test/sc_reduce.c
@@ -1,0 +1,377 @@
+/*
+ * Part of liblithium, under the Apache License v2.0.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Derived from the SUPERCOP ed25519 ref10 implementation in the public domain.
+ * https://ed25519.cr.yp.to/software.html
+ */
+
+#include "sc_reduce.h"
+
+#include <stdint.h>
+
+typedef int64_t crypto_int64;
+typedef uint32_t crypto_uint32;
+typedef uint64_t crypto_uint64;
+
+static crypto_uint64 load_3(const unsigned char *in)
+{
+    crypto_uint64 result;
+    result = (crypto_uint64)in[0];
+    result |= ((crypto_uint64)in[1]) << 8;
+    result |= ((crypto_uint64)in[2]) << 16;
+    return result;
+}
+
+static crypto_uint64 load_4(const unsigned char *in)
+{
+    crypto_uint64 result;
+    result = (crypto_uint64)in[0];
+    result |= ((crypto_uint64)in[1]) << 8;
+    result |= ((crypto_uint64)in[2]) << 16;
+    result |= ((crypto_uint64)in[3]) << 24;
+    return result;
+}
+
+/*
+Input:
+  s[0]+256*s[1]+...+256^63*s[63] = s
+
+Output:
+  r[0]+256*r[1]+...+256^31*r[31] = s mod l
+  where l = 2^252 + 27742317777372353535851937790883648493.
+*/
+
+void sc_reduce(unsigned char *r, unsigned char *s)
+{
+    crypto_int64 s0 = 2097151 & load_3(s);
+    crypto_int64 s1 = 2097151 & (load_4(s + 2) >> 5);
+    crypto_int64 s2 = 2097151 & (load_3(s + 5) >> 2);
+    crypto_int64 s3 = 2097151 & (load_4(s + 7) >> 7);
+    crypto_int64 s4 = 2097151 & (load_4(s + 10) >> 4);
+    crypto_int64 s5 = 2097151 & (load_3(s + 13) >> 1);
+    crypto_int64 s6 = 2097151 & (load_4(s + 15) >> 6);
+    crypto_int64 s7 = 2097151 & (load_3(s + 18) >> 3);
+    crypto_int64 s8 = 2097151 & load_3(s + 21);
+    crypto_int64 s9 = 2097151 & (load_4(s + 23) >> 5);
+    crypto_int64 s10 = 2097151 & (load_3(s + 26) >> 2);
+    crypto_int64 s11 = 2097151 & (load_4(s + 28) >> 7);
+    crypto_int64 s12 = 2097151 & (load_4(s + 31) >> 4);
+    crypto_int64 s13 = 2097151 & (load_3(s + 34) >> 1);
+    crypto_int64 s14 = 2097151 & (load_4(s + 36) >> 6);
+    crypto_int64 s15 = 2097151 & (load_3(s + 39) >> 3);
+    crypto_int64 s16 = 2097151 & load_3(s + 42);
+    crypto_int64 s17 = 2097151 & (load_4(s + 44) >> 5);
+    crypto_int64 s18 = 2097151 & (load_3(s + 47) >> 2);
+    crypto_int64 s19 = 2097151 & (load_4(s + 49) >> 7);
+    crypto_int64 s20 = 2097151 & (load_4(s + 52) >> 4);
+    crypto_int64 s21 = 2097151 & (load_3(s + 55) >> 1);
+    crypto_int64 s22 = 2097151 & (load_4(s + 57) >> 6);
+    crypto_int64 s23 = (load_4(s + 60) >> 3);
+    crypto_int64 carry0;
+    crypto_int64 carry1;
+    crypto_int64 carry2;
+    crypto_int64 carry3;
+    crypto_int64 carry4;
+    crypto_int64 carry5;
+    crypto_int64 carry6;
+    crypto_int64 carry7;
+    crypto_int64 carry8;
+    crypto_int64 carry9;
+    crypto_int64 carry10;
+    crypto_int64 carry11;
+    crypto_int64 carry12;
+    crypto_int64 carry13;
+    crypto_int64 carry14;
+    crypto_int64 carry15;
+    crypto_int64 carry16;
+
+    s11 += s23 * 666643;
+    s12 += s23 * 470296;
+    s13 += s23 * 654183;
+    s14 -= s23 * 997805;
+    s15 += s23 * 136657;
+    s16 -= s23 * 683901;
+    s23 = 0;
+
+    s10 += s22 * 666643;
+    s11 += s22 * 470296;
+    s12 += s22 * 654183;
+    s13 -= s22 * 997805;
+    s14 += s22 * 136657;
+    s15 -= s22 * 683901;
+    s22 = 0;
+
+    s9 += s21 * 666643;
+    s10 += s21 * 470296;
+    s11 += s21 * 654183;
+    s12 -= s21 * 997805;
+    s13 += s21 * 136657;
+    s14 -= s21 * 683901;
+    s21 = 0;
+
+    s8 += s20 * 666643;
+    s9 += s20 * 470296;
+    s10 += s20 * 654183;
+    s11 -= s20 * 997805;
+    s12 += s20 * 136657;
+    s13 -= s20 * 683901;
+    s20 = 0;
+
+    s7 += s19 * 666643;
+    s8 += s19 * 470296;
+    s9 += s19 * 654183;
+    s10 -= s19 * 997805;
+    s11 += s19 * 136657;
+    s12 -= s19 * 683901;
+    s19 = 0;
+
+    s6 += s18 * 666643;
+    s7 += s18 * 470296;
+    s8 += s18 * 654183;
+    s9 -= s18 * 997805;
+    s10 += s18 * 136657;
+    s11 -= s18 * 683901;
+    s18 = 0;
+
+    carry6 = (s6 + (1 << 20)) >> 21;
+    s7 += carry6;
+    s6 -= carry6 << 21;
+    carry8 = (s8 + (1 << 20)) >> 21;
+    s9 += carry8;
+    s8 -= carry8 << 21;
+    carry10 = (s10 + (1 << 20)) >> 21;
+    s11 += carry10;
+    s10 -= carry10 << 21;
+    carry12 = (s12 + (1 << 20)) >> 21;
+    s13 += carry12;
+    s12 -= carry12 << 21;
+    carry14 = (s14 + (1 << 20)) >> 21;
+    s15 += carry14;
+    s14 -= carry14 << 21;
+    carry16 = (s16 + (1 << 20)) >> 21;
+    s17 += carry16;
+    s16 -= carry16 << 21;
+
+    carry7 = (s7 + (1 << 20)) >> 21;
+    s8 += carry7;
+    s7 -= carry7 << 21;
+    carry9 = (s9 + (1 << 20)) >> 21;
+    s10 += carry9;
+    s9 -= carry9 << 21;
+    carry11 = (s11 + (1 << 20)) >> 21;
+    s12 += carry11;
+    s11 -= carry11 << 21;
+    carry13 = (s13 + (1 << 20)) >> 21;
+    s14 += carry13;
+    s13 -= carry13 << 21;
+    carry15 = (s15 + (1 << 20)) >> 21;
+    s16 += carry15;
+    s15 -= carry15 << 21;
+
+    s5 += s17 * 666643;
+    s6 += s17 * 470296;
+    s7 += s17 * 654183;
+    s8 -= s17 * 997805;
+    s9 += s17 * 136657;
+    s10 -= s17 * 683901;
+    s17 = 0;
+
+    s4 += s16 * 666643;
+    s5 += s16 * 470296;
+    s6 += s16 * 654183;
+    s7 -= s16 * 997805;
+    s8 += s16 * 136657;
+    s9 -= s16 * 683901;
+    s16 = 0;
+
+    s3 += s15 * 666643;
+    s4 += s15 * 470296;
+    s5 += s15 * 654183;
+    s6 -= s15 * 997805;
+    s7 += s15 * 136657;
+    s8 -= s15 * 683901;
+    s15 = 0;
+
+    s2 += s14 * 666643;
+    s3 += s14 * 470296;
+    s4 += s14 * 654183;
+    s5 -= s14 * 997805;
+    s6 += s14 * 136657;
+    s7 -= s14 * 683901;
+    s14 = 0;
+
+    s1 += s13 * 666643;
+    s2 += s13 * 470296;
+    s3 += s13 * 654183;
+    s4 -= s13 * 997805;
+    s5 += s13 * 136657;
+    s6 -= s13 * 683901;
+    s13 = 0;
+
+    s0 += s12 * 666643;
+    s1 += s12 * 470296;
+    s2 += s12 * 654183;
+    s3 -= s12 * 997805;
+    s4 += s12 * 136657;
+    s5 -= s12 * 683901;
+    s12 = 0;
+
+    carry0 = (s0 + (1 << 20)) >> 21;
+    s1 += carry0;
+    s0 -= carry0 << 21;
+    carry2 = (s2 + (1 << 20)) >> 21;
+    s3 += carry2;
+    s2 -= carry2 << 21;
+    carry4 = (s4 + (1 << 20)) >> 21;
+    s5 += carry4;
+    s4 -= carry4 << 21;
+    carry6 = (s6 + (1 << 20)) >> 21;
+    s7 += carry6;
+    s6 -= carry6 << 21;
+    carry8 = (s8 + (1 << 20)) >> 21;
+    s9 += carry8;
+    s8 -= carry8 << 21;
+    carry10 = (s10 + (1 << 20)) >> 21;
+    s11 += carry10;
+    s10 -= carry10 << 21;
+
+    carry1 = (s1 + (1 << 20)) >> 21;
+    s2 += carry1;
+    s1 -= carry1 << 21;
+    carry3 = (s3 + (1 << 20)) >> 21;
+    s4 += carry3;
+    s3 -= carry3 << 21;
+    carry5 = (s5 + (1 << 20)) >> 21;
+    s6 += carry5;
+    s5 -= carry5 << 21;
+    carry7 = (s7 + (1 << 20)) >> 21;
+    s8 += carry7;
+    s7 -= carry7 << 21;
+    carry9 = (s9 + (1 << 20)) >> 21;
+    s10 += carry9;
+    s9 -= carry9 << 21;
+    carry11 = (s11 + (1 << 20)) >> 21;
+    s12 += carry11;
+    s11 -= carry11 << 21;
+
+    s0 += s12 * 666643;
+    s1 += s12 * 470296;
+    s2 += s12 * 654183;
+    s3 -= s12 * 997805;
+    s4 += s12 * 136657;
+    s5 -= s12 * 683901;
+    s12 = 0;
+
+    carry0 = s0 >> 21;
+    s1 += carry0;
+    s0 -= carry0 << 21;
+    carry1 = s1 >> 21;
+    s2 += carry1;
+    s1 -= carry1 << 21;
+    carry2 = s2 >> 21;
+    s3 += carry2;
+    s2 -= carry2 << 21;
+    carry3 = s3 >> 21;
+    s4 += carry3;
+    s3 -= carry3 << 21;
+    carry4 = s4 >> 21;
+    s5 += carry4;
+    s4 -= carry4 << 21;
+    carry5 = s5 >> 21;
+    s6 += carry5;
+    s5 -= carry5 << 21;
+    carry6 = s6 >> 21;
+    s7 += carry6;
+    s6 -= carry6 << 21;
+    carry7 = s7 >> 21;
+    s8 += carry7;
+    s7 -= carry7 << 21;
+    carry8 = s8 >> 21;
+    s9 += carry8;
+    s8 -= carry8 << 21;
+    carry9 = s9 >> 21;
+    s10 += carry9;
+    s9 -= carry9 << 21;
+    carry10 = s10 >> 21;
+    s11 += carry10;
+    s10 -= carry10 << 21;
+    carry11 = s11 >> 21;
+    s12 += carry11;
+    s11 -= carry11 << 21;
+
+    s0 += s12 * 666643;
+    s1 += s12 * 470296;
+    s2 += s12 * 654183;
+    s3 -= s12 * 997805;
+    s4 += s12 * 136657;
+    s5 -= s12 * 683901;
+    s12 = 0;
+
+    carry0 = s0 >> 21;
+    s1 += carry0;
+    s0 -= carry0 << 21;
+    carry1 = s1 >> 21;
+    s2 += carry1;
+    s1 -= carry1 << 21;
+    carry2 = s2 >> 21;
+    s3 += carry2;
+    s2 -= carry2 << 21;
+    carry3 = s3 >> 21;
+    s4 += carry3;
+    s3 -= carry3 << 21;
+    carry4 = s4 >> 21;
+    s5 += carry4;
+    s4 -= carry4 << 21;
+    carry5 = s5 >> 21;
+    s6 += carry5;
+    s5 -= carry5 << 21;
+    carry6 = s6 >> 21;
+    s7 += carry6;
+    s6 -= carry6 << 21;
+    carry7 = s7 >> 21;
+    s8 += carry7;
+    s7 -= carry7 << 21;
+    carry8 = s8 >> 21;
+    s9 += carry8;
+    s8 -= carry8 << 21;
+    carry9 = s9 >> 21;
+    s10 += carry9;
+    s9 -= carry9 << 21;
+    carry10 = s10 >> 21;
+    s11 += carry10;
+    s10 -= carry10 << 21;
+
+    r[0] = s0 >> 0;
+    r[1] = s0 >> 8;
+    r[2] = (s0 >> 16) | (s1 << 5);
+    r[3] = s1 >> 3;
+    r[4] = s1 >> 11;
+    r[5] = (s1 >> 19) | (s2 << 2);
+    r[6] = s2 >> 6;
+    r[7] = (s2 >> 14) | (s3 << 7);
+    r[8] = s3 >> 1;
+    r[9] = s3 >> 9;
+    r[10] = (s3 >> 17) | (s4 << 4);
+    r[11] = s4 >> 4;
+    r[12] = s4 >> 12;
+    r[13] = (s4 >> 20) | (s5 << 1);
+    r[14] = s5 >> 7;
+    r[15] = (s5 >> 15) | (s6 << 6);
+    r[16] = s6 >> 2;
+    r[17] = s6 >> 10;
+    r[18] = (s6 >> 18) | (s7 << 3);
+    r[19] = s7 >> 5;
+    r[20] = s7 >> 13;
+    r[21] = s8 >> 0;
+    r[22] = s8 >> 8;
+    r[23] = (s8 >> 16) | (s9 << 5);
+    r[24] = s9 >> 3;
+    r[25] = s9 >> 11;
+    r[26] = (s9 >> 19) | (s10 << 2);
+    r[27] = s10 >> 6;
+    r[28] = (s10 >> 14) | (s11 << 7);
+    r[29] = s11 >> 1;
+    r[30] = s11 >> 9;
+    r[31] = s11 >> 17;
+}

--- a/test/sc_reduce.h
+++ b/test/sc_reduce.h
@@ -1,0 +1,14 @@
+/*
+ * Part of liblithium, under the Apache License v2.0.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Derived from the SUPERCOP ed25519 ref10 implementation in the public domain.
+ * https://ed25519.cr.yp.to/software.html
+ */
+
+#ifndef SC_REDUCE_H
+#define SC_REDUCE_H
+
+void sc_reduce(unsigned char *r, unsigned char *s);
+
+#endif // SC_REDUCE_H

--- a/test/test_reduce.c
+++ b/test/test_reduce.c
@@ -1,0 +1,103 @@
+/*
+ * Part of liblithium, under the Apache License v2.0.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <lithium/random.h>
+#include <lithium/x25519.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sc_reduce.h"
+
+static void printx(const unsigned char *x, size_t len)
+{
+    printf("0x");
+    for (int i = (int)len - 1; i >= 0; --i)
+    {
+        printf("%02hhx", x[i]);
+    }
+    printf("\n");
+}
+
+int main(void)
+{
+    for (int i = 0; i < 10000; ++i)
+    {
+        unsigned char s[X25519_LEN * 2];
+        lith_random_bytes(s, sizeof s);
+
+        unsigned char li_r[X25519_LEN];
+        unsigned char ed_r[X25519_LEN];
+
+        x25519_scalar_reduce(li_r, s);
+        sc_reduce(ed_r, s);
+
+        if (memcmp(li_r, ed_r, sizeof li_r) != 0)
+        {
+            printf("lithium and ed25519 reductions mod L do not match\n");
+            printf("s = ");
+            printx(s, sizeof s);
+            printf("li_r = ");
+            printx(li_r, sizeof li_r);
+            printf("ed_r = ");
+            printx(ed_r, sizeof ed_r);
+            return EXIT_FAILURE;
+        }
+    }
+
+    /* L = 2^252 + 27742317777372353535851937790883648493 */
+    static const unsigned char L[X25519_LEN] = {
+        0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7,
+        0xa2, 0xde, 0xf9, 0xde, 0x14, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0,
+        0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x10,
+    };
+
+    unsigned char tv[7][X25519_LEN * 2];
+    memset(tv, 0, sizeof tv);
+
+    /* L */
+    memcpy(tv[0], L, X25519_LEN);
+
+    /* L + 1 */
+    memcpy(tv[1], L, X25519_LEN);
+    tv[1][0]++;
+
+    /* L * 256 */
+    memcpy(&tv[2][1], L, X25519_LEN);
+
+    /* R = 2^256 */
+    tv[3][X25519_LEN] = 1;
+
+    /* R+1 */
+    tv[4][X25519_LEN] = 1;
+    tv[4][0] = 1;
+
+    /* 0xFF..FF */
+    memset(tv[5], 0xFF, X25519_LEN * 2);
+
+    /* tv[6] is 0 */
+
+    for (size_t t = 0; t < sizeof(tv) / sizeof(tv[0]); ++t)
+    {
+        unsigned char li_r[X25519_LEN];
+        unsigned char ed_r[X25519_LEN];
+
+        x25519_scalar_reduce(li_r, tv[t]);
+        sc_reduce(ed_r, tv[t]);
+
+        if (memcmp(li_r, ed_r, sizeof li_r) != 0)
+        {
+            printf("lithium and ed25519 reductions mod L do not match\n");
+            printf("s = ");
+            printx(tv[t], sizeof tv[t]);
+            printf("li_r = ");
+            printx(li_r, sizeof li_r);
+            printf("ed_r = ");
+            printx(ed_r, sizeof ed_r);
+            return EXIT_FAILURE;
+        }
+    }
+}

--- a/test/test_x25519.c
+++ b/test/test_x25519.c
@@ -60,9 +60,9 @@ int main(void)
     for (int i = 0; i < 10; i++)
     {
         randomize(secret1);
-        x25519_base(public1, secret1);
+        x25519_base_uniform(public1, secret1);
         randomize(eph_secret);
-        x25519_base(eph_public, eph_secret);
+        x25519_base_uniform(eph_public, eph_secret);
         randomize(challenge);
         x25519_sign(response, challenge, eph_secret, secret1);
         if (!x25519_verify(response, challenge, eph_public, public1))
@@ -170,11 +170,8 @@ int main(void)
 
     for (size_t t = 0; t < sizeof(tv) / sizeof(tv[0]); ++t)
     {
-        unsigned char sc[X25519_LEN];
-        memcpy(sc, tv[t].sc, X25519_LEN);
-        x25519_clamp(sc);
         unsigned char exp[X25519_LEN];
-        x25519(exp, sc, tv[t].u);
+        x25519(exp, tv[t].sc, tv[t].u);
         if (memcmp(exp, tv[t].exp, X25519_LEN) != 0)
         {
             printf("expected: ");


### PR DESCRIPTION
- add interface to reduce scalars mod L
- refactor x25519_q into a double loop (limbs then bits) for clarity
- add a lith_memzero function for erasing the secret scalar after use in key generation and signing
- implement the kb mask with 0 - (t'th bit of k) to more closely match RFC7748 reference code
