### PR TITLE
tms320 byte

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,3 +17,4 @@ BraceWrapping:
   SplitEmptyNamespace: true
 IndentWidth: 4
 AllowShortFunctionsOnASingleLine: false
+PenaltyBreakOpenParenthesis: 1000000

--- a/.trustinsoft/decrypt.c
+++ b/.trustinsoft/decrypt.c
@@ -11,16 +11,16 @@ int main(void)
     tis_make_unknown(ad, sizeof ad);
     tis_make_unknown(n, sizeof n);
     tis_make_unknown(k, sizeof k);
-     /*
-      * When using tis_unsigned_long_interval, TIS doesn't keep a single
-      * (arbitrary) value of len between decrypt_update and the masking loop
-      * for authentication failure, so it warns on potentially uninitialized
-      * access in the latter. This could be suppressed by initializing m up
-      * front, but this would hide all possible uninitialized accesses to m. We
-      * still want to check that all of m is set by decrypt_update, for some
-      * length, we just can't check this easily for a range of lengths at once
-      * without false positives. So just use sizeof c for len here.
-      */
+    /*
+     * When using tis_unsigned_long_interval, TIS doesn't keep a single
+     * (arbitrary) value of len between decrypt_update and the masking loop
+     * for authentication failure, so it warns on potentially uninitialized
+     * access in the latter. This could be suppressed by initializing m up
+     * front, but this would hide all possible uninitialized accesses to m. We
+     * still want to check that all of m is set by decrypt_update, for some
+     * length, we just can't check this easily for a range of lengths at once
+     * without false positives. So just use sizeof c for len here.
+     */
     size_t len = sizeof c;
     size_t tlen = tis_unsigned_long_interval(0, sizeof t);
     size_t adlen = tis_unsigned_long_interval(0, sizeof ad);

--- a/include/lithium/sign.h
+++ b/include/lithium/sign.h
@@ -27,26 +27,30 @@ void lith_sign_init(lith_sign_state *state);
 void lith_sign_update(lith_sign_state *state, const unsigned char *msg,
                       size_t len);
 
-void lith_sign_final_create(
-    lith_sign_state *state, unsigned char sig[LITH_SIGN_LEN],
-    const unsigned char secret_key[LITH_SIGN_SECRET_KEY_LEN]);
+void lith_sign_final_create(lith_sign_state *state,
+                            unsigned char sig[LITH_SIGN_LEN],
+                            const unsigned char
+                                secret_key[LITH_SIGN_SECRET_KEY_LEN]);
 
-bool lith_sign_final_verify(
-    lith_sign_state *state, const unsigned char sig[LITH_SIGN_LEN],
-    const unsigned char public_key[LITH_SIGN_PUBLIC_KEY_LEN]);
+bool lith_sign_final_verify(lith_sign_state *state,
+                            const unsigned char sig[LITH_SIGN_LEN],
+                            const unsigned char
+                                public_key[LITH_SIGN_PUBLIC_KEY_LEN]);
 
 void lith_sign_final_prehash(lith_sign_state *state,
                              unsigned char prehash[LITH_SIGN_PREHASH_LEN]);
 
-void lith_sign_create_from_prehash(
-    unsigned char sig[LITH_SIGN_LEN],
-    const unsigned char prehash[LITH_SIGN_PREHASH_LEN],
-    const unsigned char secret_key[LITH_SIGN_SECRET_KEY_LEN]);
+void lith_sign_create_from_prehash(unsigned char sig[LITH_SIGN_LEN],
+                                   const unsigned char
+                                       prehash[LITH_SIGN_PREHASH_LEN],
+                                   const unsigned char
+                                       secret_key[LITH_SIGN_SECRET_KEY_LEN]);
 
-bool lith_sign_verify_prehash(
-    const unsigned char sig[LITH_SIGN_LEN],
-    const unsigned char prehash[LITH_SIGN_PREHASH_LEN],
-    const unsigned char public_key[LITH_SIGN_PUBLIC_KEY_LEN]);
+bool lith_sign_verify_prehash(const unsigned char sig[LITH_SIGN_LEN],
+                              const unsigned char
+                                  prehash[LITH_SIGN_PREHASH_LEN],
+                              const unsigned char
+                                  public_key[LITH_SIGN_PUBLIC_KEY_LEN]);
 
 void lith_sign_create(unsigned char sig[LITH_SIGN_LEN],
                       const unsigned char *msg, size_t len,

--- a/src/gimli_common.c
+++ b/src/gimli_common.c
@@ -34,8 +34,11 @@ void gimli_store(unsigned char *p, uint32_t x)
 
 void gimli_absorb_byte(uint32_t *state, unsigned offset, unsigned char x)
 {
-#if (LITH_LITTLE_ENDIAN || LITH_BIG_ENDIAN)
-    ((unsigned char *)state)[offset ^ OFFSET_SWAP] ^= x;
+#if defined(__TMS320C2000__)
+    __byte((int *)state, offset) ^= x;
+#elif ((LITH_LITTLE_ENDIAN || LITH_BIG_ENDIAN) && (CHAR_BIT == 8))
+    offset ^= OFFSET_SWAP;
+    ((unsigned char *)state)[offset] ^= x;
 #else
     state[offset / 4] ^= (uint32_t)x << ((offset % 4) * 8);
 #endif
@@ -43,8 +46,11 @@ void gimli_absorb_byte(uint32_t *state, unsigned offset, unsigned char x)
 
 unsigned char gimli_squeeze_byte(const uint32_t *state, unsigned offset)
 {
-#if (LITH_LITTLE_ENDIAN || LITH_BIG_ENDIAN)
-    return ((const unsigned char *)state)[offset ^ OFFSET_SWAP];
+#if defined(__TMS320C2000__)
+    return (unsigned char)__byte((int *)state, offset);
+#elif ((LITH_LITTLE_ENDIAN || LITH_BIG_ENDIAN) && (CHAR_BIT == 8))
+    offset ^= OFFSET_SWAP;
+    return ((const unsigned char *)state)[offset];
 #else
     return (unsigned char)((state[offset / 4] >> ((offset % 4) * 8)) & 0xFFU);
 #endif

--- a/src/opt.h
+++ b/src/opt.h
@@ -13,29 +13,39 @@
  * On little-endian 8-bit byte platforms, accessing the Gimli
  * state words can be done directly with byte accesses.
  */
-#if !defined(LITH_LITTLE_ENDIAN) &&                                            \
-    (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__))
-#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && (CHAR_BIT == 8)
+#if !defined(LITH_LITTLE_ENDIAN)
+
+#if (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__))
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 #define LITH_LITTLE_ENDIAN 1
 #endif
+#elif defined(__LITTLE_ENDIAN__)
+#define LITH_LITTLE_ENDIAN 1
 #endif
+
+#endif /* !defined(LITH_LITTLE_ENDIAN) */
+
+#if !defined(LITH_BIG_ENDIAN)
+
+#if (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__))
+#if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define LITH_BIG_ENDIAN 1
+#endif
+#elif defined(__BIG_ENDIAN__)
+#define LITH_BIG_ENDIAN 1
+#endif
+
+#endif /* !defined(LITH_BIG_ENDIAN) */
 
 #ifndef LITH_LITTLE_ENDIAN
 #define LITH_LITTLE_ENDIAN 0
-#endif
-
-#if !defined(LITH_BIG_ENDIAN) &&                                            \
-    (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__))
-#if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) && (CHAR_BIT == 8)
-#define LITH_BIG_ENDIAN 1
-#endif
 #endif
 
 #ifndef LITH_BIG_ENDIAN
 #define LITH_BIG_ENDIAN 0
 #endif
 
-#if (LITH_BIG_ENDIAN && LITH_LITTLE_ENDIAN)
+#if (LITH_LITTLE_ENDIAN && LITH_BIG_ENDIAN)
 #error "cannot be both little- and big-endian"
 #endif
 

--- a/src/sign.c
+++ b/src/sign.c
@@ -49,10 +49,11 @@ gen_challenge(gimli_hash_state *state, unsigned char challenge[X25519_LEN],
     x25519_scalar_reduce(challenge, challenge_unreduced);
 }
 
-void lith_sign_create_from_prehash(
-    unsigned char sig[LITH_SIGN_LEN],
-    const unsigned char prehash[LITH_SIGN_PREHASH_LEN],
-    const unsigned char secret_key[LITH_SIGN_SECRET_KEY_LEN])
+void lith_sign_create_from_prehash(unsigned char sig[LITH_SIGN_LEN],
+                                   const unsigned char
+                                       prehash[LITH_SIGN_PREHASH_LEN],
+                                   const unsigned char
+                                       secret_key[LITH_SIGN_SECRET_KEY_LEN])
 {
     /* The two signature components. */
     unsigned char *const public_nonce = &sig[0];
@@ -96,19 +97,21 @@ void lith_sign_final_prehash(lith_sign_state *state,
     gimli_hash_final(state, prehash, LITH_SIGN_PREHASH_LEN);
 }
 
-void lith_sign_final_create(
-    lith_sign_state *state, unsigned char sig[LITH_SIGN_LEN],
-    const unsigned char secret_key[LITH_SIGN_SECRET_KEY_LEN])
+void lith_sign_final_create(lith_sign_state *state,
+                            unsigned char sig[LITH_SIGN_LEN],
+                            const unsigned char
+                                secret_key[LITH_SIGN_SECRET_KEY_LEN])
 {
     unsigned char prehash[LITH_SIGN_PREHASH_LEN];
     lith_sign_final_prehash(state, prehash);
     lith_sign_create_from_prehash(sig, prehash, secret_key);
 }
 
-bool lith_sign_verify_prehash(
-    const unsigned char sig[LITH_SIGN_LEN],
-    const unsigned char prehash[LITH_SIGN_PREHASH_LEN],
-    const unsigned char public_key[LITH_SIGN_PUBLIC_KEY_LEN])
+bool lith_sign_verify_prehash(const unsigned char sig[LITH_SIGN_LEN],
+                              const unsigned char
+                                  prehash[LITH_SIGN_PREHASH_LEN],
+                              const unsigned char
+                                  public_key[LITH_SIGN_PUBLIC_KEY_LEN])
 {
     const unsigned char *const public_nonce = &sig[0];
     const unsigned char *const response = &sig[X25519_LEN];
@@ -120,9 +123,10 @@ bool lith_sign_verify_prehash(
     return x25519_verify(response, challenge, public_nonce, public_key);
 }
 
-bool lith_sign_final_verify(
-    lith_sign_state *state, const unsigned char sig[LITH_SIGN_LEN],
-    const unsigned char public_key[LITH_SIGN_PUBLIC_KEY_LEN])
+bool lith_sign_final_verify(lith_sign_state *state,
+                            const unsigned char sig[LITH_SIGN_LEN],
+                            const unsigned char
+                                public_key[LITH_SIGN_PUBLIC_KEY_LEN])
 {
     unsigned char prehash[LITH_SIGN_PREHASH_LEN];
     lith_sign_final_prehash(state, prehash);


### PR DESCRIPTION
- add optimized squeeze and absorb using __byte instrinsic for tms320
- update .clang-format to avoid breaking after parens
