### PR TITLE
simplify

### DIFF
--- a/src/fe.c
+++ b/src/fe.c
@@ -157,15 +157,12 @@ limb canon(fe a)
      * Precondition: x < 2^255 + 1 word
      */
     sdlimb carry_sub = -19;
-    limb res = 0, carry_add = 19;
+    limb res = 0;
     int i;
 
     /* First, add 19. */
-    for (i = 0; i < NLIMBS; ++i)
-    {
-        a[i] = adc(&carry_add, a[i], 0);
-    }
-    propagate(a, carry_add);
+    const fe nineteen = {19};
+    add(a, a, nineteen);
 
     /*
      * Here, 19 <= x2 < 2^255

--- a/src/gimli.c
+++ b/src/gimli.c
@@ -80,18 +80,12 @@ void gimli(uint32_t state[GIMLI_WORDS])
 
 #else /* !LITH_VECTORIZE */
 
-static void swap(uint32_t *x, int i, int j)
-{
-    const uint32_t tmp = x[i];
-    x[i] = x[j];
-    x[j] = tmp;
-}
-
 void gimli(uint32_t state[GIMLI_WORDS])
 {
     int round;
     for (round = 24; round > 0; --round)
     {
+        uint32_t tmp;
         int column;
         for (column = 0; column < 4; ++column)
         {
@@ -106,15 +100,22 @@ void gimli(uint32_t state[GIMLI_WORDS])
         {
         case 0:
             /* small swap: pattern s...s...s... etc. */
-            swap(state, 0, 1);
-            swap(state, 2, 3);
             /* add constant: pattern c...c...c... etc. */
-            state[0] ^= coeff(round);
+            tmp = state[0];
+            state[0] = state[1] ^ coeff(round);
+            state[1] = tmp;
+            tmp = state[2];
+            state[2] = state[3];
+            state[3] = tmp;
             break;
         case 2:
             /* big swap: pattern ..S...S...S. etc. */
-            swap(state, 0, 2);
-            swap(state, 1, 3);
+            tmp = state[0];
+            state[0] = state[2];
+            state[2] = tmp;
+            tmp = state[1];
+            state[1] = state[3];
+            state[3] = tmp;
             break;
         }
     }

--- a/src/gimli_aead.c
+++ b/src/gimli_aead.c
@@ -36,23 +36,21 @@ void gimli_aead_update_ad(gimli_state *g, const unsigned char *ad, size_t adlen)
 
 void gimli_aead_final_ad(gimli_state *g)
 {
-    gimli_pad(g->state, g->offset);
+    gimli_pad(g);
     g->offset = GIMLI_RATE - 1;
-    gimli_advance(g->state, &g->offset);
+    gimli_advance(g);
 }
 
 static void encrypt_update(gimli_state *g, unsigned char *c,
                            const unsigned char *m, size_t len)
 {
     size_t i;
-    unsigned offset = g->offset;
     for (i = 0; i < len; ++i)
     {
-        gimli_absorb_byte(g->state, offset, m[i]);
-        c[i] = gimli_squeeze_byte(g->state, offset);
-        gimli_advance(g->state, &offset);
+        gimli_absorb_byte(g, m[i]);
+        c[i] = gimli_squeeze_byte(g);
+        gimli_advance(g);
     }
-    g->offset = offset;
 }
 
 void gimli_aead_encrypt_update(gimli_state *g, unsigned char *c,
@@ -92,7 +90,7 @@ void gimli_aead_encrypt_update(gimli_state *g, unsigned char *c,
 
 void gimli_aead_encrypt_final(gimli_state *g, unsigned char *t, size_t len)
 {
-    gimli_pad(g->state, g->offset);
+    gimli_pad(g);
     gimli_squeeze(g, t, len);
 }
 
@@ -100,14 +98,12 @@ static void decrypt_update(gimli_state *g, unsigned char *m,
                            const unsigned char *c, size_t len)
 {
     size_t i;
-    unsigned offset = g->offset;
     for (i = 0; i < len; ++i)
     {
-        m[i] = c[i] ^ gimli_squeeze_byte(g->state, offset);
-        gimli_absorb_byte(g->state, offset, m[i]);
-        gimli_advance(g->state, &offset);
+        m[i] = c[i] ^ gimli_squeeze_byte(g);
+        gimli_absorb_byte(g, m[i]);
+        gimli_advance(g);
     }
-    g->offset = offset;
 }
 
 void gimli_aead_decrypt_update(gimli_state *g, unsigned char *m,
@@ -165,13 +161,12 @@ bool gimli_aead_decrypt_final(gimli_state *g, const unsigned char *t,
 {
     unsigned char mismatch = 0;
     size_t i;
-    unsigned offset = g->offset;
-    gimli_pad(g->state, offset);
-    offset = GIMLI_RATE - 1;
+    gimli_pad(g);
+    g->offset = GIMLI_RATE - 1;
     for (i = 0; i < tlen; ++i)
     {
-        gimli_advance(g->state, &offset);
-        mismatch |= t[i] ^ gimli_squeeze_byte(g->state, offset);
+        gimli_advance(g);
+        mismatch |= t[i] ^ gimli_squeeze_byte(g);
     }
     return mismatch == 0;
 }

--- a/src/gimli_common.c
+++ b/src/gimli_common.c
@@ -32,62 +32,59 @@ void gimli_store(unsigned char *p, uint32_t x)
 #define OFFSET_SWAP 3U
 #endif
 
-void gimli_absorb_byte(uint32_t *state, unsigned offset, unsigned char x)
+void gimli_absorb_byte(gimli_state *g, unsigned char x)
 {
 #if defined(__TMS320C2000__)
-    __byte((int *)state, offset) ^= x;
+    __byte((int *)g->state, g->offset) ^= x;
 #elif ((LITH_LITTLE_ENDIAN || LITH_BIG_ENDIAN) && (CHAR_BIT == 8))
-    offset ^= OFFSET_SWAP;
-    ((unsigned char *)state)[offset] ^= x;
+    ((unsigned char *)g->state)[g->offset ^ OFFSET_SWAP] ^= x;
 #else
-    state[offset / 4] ^= (uint32_t)x << ((offset % 4) * 8);
+    g->state[g->offset / 4] ^= (uint32_t)x << ((g->offset % 4) * 8);
 #endif
 }
 
-unsigned char gimli_squeeze_byte(const uint32_t *state, unsigned offset)
+unsigned char gimli_squeeze_byte(const gimli_state *g)
 {
 #if defined(__TMS320C2000__)
-    return (unsigned char)__byte((int *)state, offset);
+    return (unsigned char)__byte((int *)g->state, g->offset);
 #elif ((LITH_LITTLE_ENDIAN || LITH_BIG_ENDIAN) && (CHAR_BIT == 8))
-    offset ^= OFFSET_SWAP;
-    return ((const unsigned char *)state)[offset];
+    return ((const unsigned char *)g->state)[g->offset ^ OFFSET_SWAP];
 #else
-    return (unsigned char)((state[offset / 4] >> ((offset % 4) * 8)) & 0xFFU);
+    return (unsigned char)((g->state[g->offset / 4] >> ((g->offset % 4) * 8)) &
+                           0xFFU);
 #endif
 }
 
-void gimli_advance(uint32_t *state, unsigned *offset)
+void gimli_advance(gimli_state *g)
 {
-    ++*offset;
-    if (*offset == GIMLI_RATE)
+    ++g->offset;
+    if (g->offset == GIMLI_RATE)
     {
 #if (LITH_ENABLE_WATCHDOG)
         lith_watchdog_pet();
 #endif
-        gimli(state);
-        *offset = 0;
+        gimli(g->state);
+        g->offset = 0;
     }
 }
 
-static void absorb(uint32_t *state, unsigned *offset, const unsigned char *m,
-                   size_t len)
+static void absorb(gimli_state *g, const unsigned char *m, size_t len)
 {
     size_t i;
     for (i = 0; i < len; ++i)
     {
-        gimli_absorb_byte(state, *offset, m[i]);
-        gimli_advance(state, offset);
+        gimli_absorb_byte(g, m[i]);
+        gimli_advance(g);
     }
 }
 
 void gimli_absorb(gimli_state *g, const unsigned char *m, size_t len)
 {
-    unsigned offset = g->offset;
 #if (LITH_SPONGE_WORDS)
-    const unsigned first_block_len = (GIMLI_RATE - offset) % GIMLI_RATE;
+    const unsigned first_block_len = (GIMLI_RATE - g->offset) % GIMLI_RATE;
     if (len >= GIMLI_RATE + first_block_len)
     {
-        absorb(g->state, &offset, m, first_block_len);
+        absorb(g, m, first_block_len);
         m += first_block_len;
         len -= first_block_len;
         do
@@ -108,24 +105,22 @@ void gimli_absorb(gimli_state *g, const unsigned char *m, size_t len)
         } while (len >= GIMLI_RATE);
     }
 #endif
-    absorb(g->state, &offset, m, len);
-    g->offset = offset;
+    absorb(g, m, len);
 }
 
 void gimli_squeeze(gimli_state *g, unsigned char *h, size_t len)
 {
     size_t i;
-    unsigned offset = GIMLI_RATE - 1;
+    g->offset = GIMLI_RATE - 1;
     for (i = 0; i < len; ++i)
     {
-        gimli_advance(g->state, &offset);
-        h[i] = gimli_squeeze_byte(g->state, offset);
+        gimli_advance(g);
+        h[i] = gimli_squeeze_byte(g);
     }
-    g->offset = offset;
 }
 
-void gimli_pad(uint32_t *state, unsigned offset)
+void gimli_pad(gimli_state *g)
 {
-    gimli_absorb_byte(state, offset, 0x01);
-    state[GIMLI_WORDS - 1] ^= UINT32_C(0x01000000);
+    gimli_absorb_byte(g, 0x01);
+    g->state[GIMLI_WORDS - 1] ^= UINT32_C(0x01000000);
 }

--- a/src/gimli_common.h
+++ b/src/gimli_common.h
@@ -10,13 +10,13 @@
 
 #include <stdint.h>
 
-void gimli_absorb_byte(uint32_t *state, unsigned offset, unsigned char x);
+void gimli_absorb_byte(gimli_state *g, unsigned char x);
 
-unsigned char gimli_squeeze_byte(const uint32_t *state, unsigned offset);
+unsigned char gimli_squeeze_byte(const gimli_state *g);
 
-void gimli_advance(uint32_t *g, unsigned *offset);
+void gimli_advance(gimli_state *g);
 
-void gimli_pad(uint32_t *state, unsigned offset);
+void gimli_pad(gimli_state *g);
 
 uint32_t gimli_load(const unsigned char *p);
 

--- a/src/gimli_hash.c
+++ b/src/gimli_hash.c
@@ -21,7 +21,7 @@ void gimli_hash_update(gimli_hash_state *g, const unsigned char *m, size_t len)
 
 void gimli_hash_final(gimli_hash_state *g, unsigned char *h, size_t len)
 {
-    gimli_pad(g->state, g->offset);
+    gimli_pad(g);
     gimli_squeeze(g, h, len);
 }
 

--- a/src/x25519.c
+++ b/src/x25519.c
@@ -302,10 +302,10 @@ bool x25519_verify(const unsigned char response[X25519_LEN],
     feq P, Q;
     fe A, B = {BASE_POINT};
 
+    read_limbs(A, public_key);
+
     x25519_q(P, response, B);
     /* P = x/z = response*base_point */
-
-    read_limbs(A, public_key);
     x25519_q(Q, challenge, A);
     /* Q = u/w = challenge*public_key */
 
@@ -325,8 +325,8 @@ bool x25519_verify(const unsigned char response[X25519_LEN],
     mul1(A, B);
     /* A = left = 16uwR(xx + axz + zz) */
 
-    mul1(Z(Q), B);
-    sub(B, Z(Q), X(Q));
+    mul1(B, Z(Q));
+    sub(B, B, X(Q));
     sqr1(B);
     /* B = right = (R(2zu - 2xw) - (2xu - 2zw))^2 */
 


### PR DESCRIPTION
- switch back to a single loop for x25519_q
- modify ordering and temporaries within x25519_verify to save code size
- re-use add in canon
- undo split offset in gimli_common functions
- don't use swap function
